### PR TITLE
Allow requests to load.php from other domains (Allow CORS)

### DIFF
--- a/load.php
+++ b/load.php
@@ -1,4 +1,5 @@
 <?php
+    header("Access-Control-Allow-Origin: *");
     $opts = [
         "http" => [
             "method" => "GET",


### PR DESCRIPTION
PR od [@viotalJiplk](https://github.com/viotalJiplk)

Added header `Access-Control-Allow-Origin: *` to load.php. Now you can use it even if not on same domain.